### PR TITLE
Add Archlinux packages to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,11 +2,17 @@
 Work in Progress TF2 GNU Linux Dynamic Library.
 
 ### Dependencies:
+(Debian)
 - `gdb`
 - `gcc`
 - `libsdl2-dev`
 - `libglew-dev` (2.1, [see below](#runtime-environment))
 - `ProggySquare.tff` (Download [here](https://github.com/bluescan/proggyfonts/blob/master/ProggyOriginal/ProggySquare.ttf))
+
+(Arch)
+- `base-devel`
+- `glew` and [`glew-2.1`](https://aur.archlinux.org/packages/glew-2.1)
+- [`ProggyFonts`](https://aur.archlinux.org/packages/proggyfonts)
 
 ### Runtime Environment
 The Steam Runtime Environment containerizes Team Fortress for portability and compatibility between distros. The runtime uses Linux namespaces to build a predictable environment. You can read more [here](https://gitlab.steamos.cloud/steamrt/steam-runtime-tools/-/blob/main/docs/container-runtime.md#steam-linux-runtime-30-sniper). What this means for us is that we must match the versions and paths of the libraries we link with against the versions and paths present in the container's namespace.

--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ Work in Progress TF2 GNU Linux Dynamic Library.
 
 (Arch)
 - `base-devel`
+- `sdl2`
 - `glew` and [`glew-2.1`](https://aur.archlinux.org/packages/glew-2.1)
 - [`ProggyFonts`](https://aur.archlinux.org/packages/proggyfonts)
 


### PR DESCRIPTION
Hello, I've recently installed Arch on my desktop and found that this project was lacking instructions on where to get the necessary resources for the distribution.

I've added them to the README file, and separate distinctions to which packages go to which distro.

More info:
1. `base-devel` is a meta package for development on Arch that contains things like `gcc` and `gdb`.

2. `sdl2` is SDL :P 

3. Both `glew` and `glew-2.1` are needed as `glew` is what contains the header files, and `glew-2.1` contains the linkable binary for its respective version.

4. Lastly, since Arch doesn't have a default font manager, it depends on what software the user has installed; I've linked the AUR package for the font, as it will automatically install it to the system without needing to download an individual file of a repository.

Cheers, and happy new year.