### PR TITLE
Add `gdb` to README.md

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,12 +1,12 @@
-# tf_c bin/log files
-tf_c.log
-tf_c.so
+# Compiled objects
+*.o
+*.obj
+
+# Compiled dynamic libraries
+*.so
 
 # vscode project file
 .vscode
 
 # Emacs tilde files
 *~
-
-# Config files
-*.tf_c.bin

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,30 @@
+CC=gcc
+
+MAKEFLAGS := --jobs=$(shell nproc)
+
+CFLAGS= -shared -fpic -g
+
+LDFLAGS= -l:libGLEW.so.2.1 -lSDL2 -g
+
+OBJ_FILES=$(shell find . -name '*.c' | sed -e "s/$$/.o/")
+OBJS=$(addprefix obj/, $(OBJ_FILES))
+BIN=tf_c.so
+
+.PHONY: all clean
+
+#-------------------------------------------------------------------------------
+
+all: $(BIN)
+
+clean:
+	rm -f $(OBJS)
+	rm -f $(BIN)
+
+#-------------------------------------------------------------------------------
+
+$(BIN): $(OBJS)
+	$(CC) $(CFLAGS) -o $@ $^ $(LDFLAGS)
+
+obj/%.c.o: %.c
+	@mkdir -p $(dir $@)
+	$(CC) $(CFLAGS) -c -o $@ $<

--- a/hooks/hooks.c
+++ b/hooks/hooks.c
@@ -47,12 +47,14 @@ bool init_hooks()
     create_move_original = client_mode_vtable[create_move_index];
     log_msg("CreateMove found at %p\n", create_move_original);
 
+    /*
     if (!write_to_table(client_mode_vtable, create_move_index, create_move_hook))
     {
         log_msg("Failed to hook CreateMove\n");
         return false;
     }
-
+    */
+    
     paint_traverse_original = vgui_panel_vtable[paint_traverse_index];
     log_msg("PaintTraverse found at %p\n", paint_traverse_original);
 

--- a/inject.sh
+++ b/inject.sh
@@ -1,0 +1,35 @@
+#!/bin/bash
+
+LIB_PATH=$(pwd)/tf_c.so
+PROCID=$(pgrep tf_linux64 | head -n 1)
+
+unload() {
+    echo -e "\nUnloading library with handle $LIB_HANDLE"
+    
+    RC=$(gdb -n --batch -ex "attach $PROCID" \
+             -ex "call ((int (*) (void *)) dlclose)((void *) $LIB_HANDLE)" \
+             -ex "call ((char * (*) (void)) dlerror)()" \
+             -ex "detach" 2> /dev/null | grep -oP '\$2 = 0x\K[0-9a-f]+')
+    
+    if [[ "$RC" == "0" ]]; then
+        echo "Library unloaded successfully"
+    else
+        echo "Failed to unload library"
+    fi
+}
+
+trap unload SIGINT
+
+LIB_HANDLE=$(sudo gdb -n --batch -ex "attach $PROCID" \
+                  -ex "call ((void * (*) (const char*, int)) dlopen)(\"$LIB_PATH\", 1)" \
+                  -ex "detach" 2> /dev/null | grep -oP '\$1 = \(void \*\) \K0x[0-9a-f]+')
+
+if [ -z "$LIB_HANDLE" ]; then
+    echo "Failed to load library"
+    exit 1
+fi
+
+echo "Library loaded successfully at $LIB_HANDLE. Use Ctrl+C to unload."
+
+# Logs are printed to STDERR, watch load logs via `cat /proc/$(pidof tf_linux64)/fd/2` from another terminal
+cat /proc/$(pidof tf_linux64)/fd/2


### PR DESCRIPTION
Fixing the first point listed in #16 

I had looked at the `base-devel` package on the Archlinux site, but I don't exactly know how I missed it. The program still compiled and ran fine without me manually installing `gdb`, so it was most likely that another package I installed had it as a dependency.